### PR TITLE
Add SWE-PolyBench 500 subset (Child Issue 4)

### DIFF
--- a/external/swe-polybench/README.md
+++ b/external/swe-polybench/README.md
@@ -1,0 +1,41 @@
+# SWE-PolyBench 500 Subset (Child Issue 4)
+
+## Important: This is not a C/C++ dataset
+
+**SWE-PolyBench 500 contains only Java, JavaScript, TypeScript, and Python** (125 issues per language). There are no C/C++ issues. We do **not** produce a C/C++ subset file—use SWE-Bench Multilingual (Issue 1), Defects4C (Issue 2), BugSwarm (Issue 3), or the Boost/Clang plan (Issue 6) for C/C++.
+
+## Layout
+
+- **scripts/download.py** — Download 500 subset from Hugging Face (`AmazonScience/SWE-PolyBench_500`), write `data/polybench_500.jsonl`.
+- **data/polybench_500.jsonl** — Full 500 issues (one JSON per line). Each has: `language`, `repo`, `issue_text`, `test_cmd`, `expected_patch`, plus `instance_id`, `base_commit`, `F2P`, `P2P`, `task_category`, etc.
+- **evaluation/evaluate.py** — Evaluation runner: accuracy/pass-rate. Use `--use-official --polybench-repo /path/to/SWE-PolyBench` to run the official harness.
+- **docs/methodology.md** — Research Q&A, issue selection, language coverage, difficulty, test generation, replication plan for Boost/Clang.
+
+## Quick start
+
+```bash
+cd external/swe-polybench
+pip install -r scripts/requirements.txt
+python scripts/download.py
+```
+
+Then run evaluation (lightweight: just validates predictions; for full pass-rate use official repo):
+
+```bash
+python evaluation/evaluate.py --dataset-path data/polybench_500.jsonl --predictions-path predictions.jsonl --result-path ./eval_results
+# Full evaluation (requires clone of amazon-science/SWE-PolyBench):
+python evaluation/evaluate.py --dataset-path data/polybench_500.jsonl --predictions-path predictions.jsonl --result-path ./eval_results --use-official --polybench-repo /path/to/SWE-PolyBench
+```
+
+## Acceptance criteria (Child Issue 4)
+
+- **500-issue dataset** downloadable via `python scripts/download.py`.
+- **C/C++:** The 500 subset has **no C/C++**; no C/C++ subset file is produced (deliverable N/A). Use other benchmarks in this repo for C/C++.
+- **Evaluation script** returns accuracy/pass-rate (via official harness when `--use-official`).
+- **Per issue:** `language`, `repo`, `issue_text`, `test_cmd`, `expected_patch` (and `instance_id`, `base_commit`, F2P, P2P, etc.).
+
+## References
+
+- [Hugging Face: AmazonScience/SWE-PolyBench_500](https://huggingface.co/datasets/AmazonScience/SWE-PolyBench_500)
+- [GitHub: amazon-science/SWE-PolyBench](https://github.com/amazon-science/SWE-PolyBench)
+- [Leaderboard & docs](https://amazon-science.github.io/SWE-PolyBench/)

--- a/external/swe-polybench/docs/methodology.md
+++ b/external/swe-polybench/docs/methodology.md
@@ -1,0 +1,104 @@
+# SWE-PolyBench 500 Subset: Methodology
+
+## Disclaimer: Not a C/C++ dataset
+
+**SWE-PolyBench 500 does not contain C/C++.** The official 500 subset includes only Java, JavaScript, TypeScript, and Python (125 instances per language). There are **zero** C/C++ issues. We do **not** produce a C/C++ subset file. This benchmark cannot be used for C/C++ agent evaluation. For C/C++ use other benchmarks in this repo (e.g. SWE-Bench Multilingual, Defects4C, BugSwarm, Boost/Clang plan).
+
+---
+
+This document answers the research questions for Child Issue 4 and describes issue selection, language coverage, difficulty, test generation, and the replication plan for Boost/Clang.
+
+## Research questions
+
+### What is SWE-PolyBench and how does it differ from SWE-Bench?
+
+- **SWE-PolyBench** is a **multi-language**, **repository-level** benchmark for evaluating coding agents. It contains curated issues (bug fixes, features, refactoring) from real GitHub repos, with per-instance Dockerfiles and test commands. It covers **Java, JavaScript, TypeScript, and Python** (no C/C++ in the current release).
+- **SWE-Bench** is **Python-focused**, issue-to-patch benchmark with a single language and different task sourcing. SWE-PolyBench generalizes the idea to multiple languages and adds stratified subsets (500, Verified) and retrieval-oriented metrics (file/node precision/recall).
+
+### Where is the official dataset/repository hosted?
+
+- **Datasets:** Hugging Face — `AmazonScience/SWE-PolyBench` (full 2,110), `AmazonScience/SWE-PolyBench_500` (500 subset), `AmazonScience/SWE-PolyBench_Verified` (394 verified).
+- **Code and evaluation:** GitHub — [amazon-science/SWE-PolyBench](https://github.com/amazon-science/SWE-PolyBench). Evaluation script: `src/poly_bench_evaluation/run_evaluation.py`.
+- **Documentation / leaderboard:** [amazon-science.github.io/SWE-PolyBench](https://amazon-science.github.io/SWE-PolyBench).
+
+### What languages are included in the 500 subset?
+
+- **Four languages:** Java, JavaScript, TypeScript, Python. **125 instances per language** (500 total). The benchmark does **not** include C/C++.
+
+### How many C/C++ issues are in the 500 subset?
+
+- **Zero.** The 500 subset is stratified across Java, JavaScript, TypeScript, and Python only. There are no C/C++ instances. We do not produce a C/C++ subset file. **Do not use SWE-PolyBench 500 for C/C++ evaluation.**
+
+### What is the task format? (issue description, expected output, tests)
+
+- **Per instance:** `instance_id`, `repo`, `base_commit`, `problem_statement` (issue title + body), `patch` (gold patch), `test_patch`, `test_command`, `F2P` (fail-to-pass tests), `P2P` (pass-to-pass tests), `language`, `task_category` (Bug Fix / Feature / Refactoring), `Dockerfile` (instance-level). Our JSONL uses `issue_text` = `problem_statement`, `test_cmd` = `test_command`, `expected_patch` = `patch`.
+
+### Is there an official evaluation script?
+
+- **Yes.** In the GitHub repo: `src/poly_bench_evaluation/run_evaluation.py`. It takes `--dataset-path` (Hugging Face dataset name), `--predictions-path` (JSONL with `instance_id`, `model_patch`), `--result-path`, and optional `--evaluate-gold`, `--num-threads`, `--repo-path`, `--delete-image`, etc. It runs instance-level Docker builds/tests and outputs pass rate and instance-level results. Our `evaluation/evaluate.py` can call this when `--use-official --polybench-repo` are provided.
+
+### What repositories/projects are sources for the issues?
+
+- Issues are drawn from **21 repositories** across the four languages (see the paper/dataset). Repos are identified by the `repo` field (e.g. GitHub owner/name). The full dataset lists them; the 500 subset is a stratified sample from the full set.
+
+### How are issues validated for correctness?
+
+- **Gold patch:** The solution patch comes from the merged PR that resolved the issue. **Tests:** F2P (tests that were failing and are fixed by the PR) and P2P (tests that must remain passing). The official evaluator runs the test command inside an instance-specific Docker image and checks F2P/P2P outcomes. The **Verified** subset (394 instances) has additional curation and updated Dockerfiles for a 100% gold pass rate.
+
+### What difficulty levels or categories exist?
+
+- **Task categories:** Bug Fix, Feature, Refactoring (in the 500 subset roughly 40% Bug Fix, 40% Feature, 20% Refactoring). The dataset also includes retrieval-related flags (`is_func_only`, `is_class_only`, `num_func_changes`, etc.) used for file/node-level difficulty and metric computation.
+
+## Methodology documentation requirements
+
+### Issue selection (how were the 500 issues selected?)
+
+- The 500 subset is a **stratified sample** from the full SWE-PolyBench (2,110 instances): 125 instances per language (Java, JavaScript, TypeScript, Python) and a balanced distribution of task categories (40% Bug Fix, 40% Feature, 20% Refactoring). So selection is by language balance and task-type balance from the full set.
+
+### Multi-language coverage
+
+- Language balance was achieved by **stratified sampling**: exactly 125 instances from each of the four languages in the full benchmark, so the 500 subset is language-balanced by design.
+
+### Difficulty calibration
+
+- Difficulty is reflected by **task category** (Bug Fix, Feature, Refactoring) and by retrieval-oriented fields (e.g. function-only vs class-level changes, number of changed nodes). The benchmark does not publish a single numeric difficulty rating; difficulty is inferred from category and retrieval metrics.
+
+### Test generation
+
+- **Tests** are tied to the merged PR: F2P tests are those that failed before and pass after the fix; P2P tests must pass before and after. The `test_patch` and `test_command` come from the solution PR. The official evaluator runs the instance Docker image and executes the test command to validate F2P/P2P; the Verified subset has Dockerfiles that achieve 100% gold pass rate.
+
+## Replication plan for Boost/Clang
+
+### Selection criteria for Boost issues
+
+- Must have **clear issue description** (e.g. on GitHub).
+- Must have an **associated test case** (failing test that the fix resolves).
+- **Patch size:** target 1–100 lines (configurable).
+- **Coverage:** span **different Boost libraries** (e.g. Beast, Asio, JSON, etc.).
+
+### Selection criteria for Clang issues
+
+- **Source:** LLVM bug tracker (e.g. Bugzilla, GitHub issues).
+- **Scope:** include **frontend, optimizer, and backend** issues.
+- Must have a **regression test** (e.g. lit test or reduced case).
+- **Difficulty:** cover different difficulty levels (e.g. one-line fixes vs multi-file changes).
+
+### Application
+
+- For **Boost**, we would collect issues that meet the above criteria, then produce a catalog (e.g. JSONL) with `repo`, `issue_text`, `test_cmd`, `expected_patch`, and optional difficulty/category, and run evaluation via a Boost-specific harness (build + run tests).
+- For **Clang**, we would collect LLVM/Clang issues with regression tests, catalog them similarly, and evaluate with a Clang test harness (e.g. `ninja check-clang` or targeted lit tests). The *structure* (issue, test command, gold patch, pass/fail) mirrors SWE-PolyBench; the *environment* (Boost/Clang repos and test runners) is domain-specific.
+
+## Summary
+
+| Topic | Answer |
+|-------|--------|
+| SWE-PolyBench vs SWE-Bench | Multi-language, repo-level; SWE-Bench is Python-focused |
+| Hosting | Hugging Face (AmazonScience/SWE-PolyBench_500); GitHub (evaluation code) |
+| Languages in 500 | Java, JavaScript, TypeScript, Python (125 each) |
+| C/C++ in 500 | **0.** No C/C++ subset produced. Do not use for C/C++ evaluation. |
+| Task format | instance_id, repo, problem_statement, patch, test_command, F2P, P2P, language, task_category, Dockerfile |
+| Official evaluation | run_evaluation.py in repo; our evaluate.py can delegate with --use-official |
+| Issue sources | 21 repos across 4 languages |
+| Validation | Gold patch from PR; F2P/P2P tests; Verified subset has curated Dockerfiles |
+| Categories | Bug Fix, Feature, Refactoring (40-40-20 in 500) |
+| Replication Boost/Clang | Selection criteria above; same catalog + harness pattern |

--- a/external/swe-polybench/eval_out/evaluate_summary.json
+++ b/external/swe-polybench/eval_out/evaluate_summary.json
@@ -1,0 +1,6 @@
+{
+  "num_predictions": 500,
+  "pass_rate": null,
+  "resolved": null,
+  "note": "Run with --use-official --polybench-repo /path/to/SWE-PolyBench for full pass-rate evaluation."
+}

--- a/external/swe-polybench/evaluation/evaluate.py
+++ b/external/swe-polybench/evaluation/evaluate.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""
+Evaluation runner for SWE-PolyBench: compute accuracy/pass-rate from predictions.
+
+NOTE: SWE-PolyBench 500 has no C/C++ issues (Java, JS, TS, Python only).
+Use data/polybench_500.jsonl for evaluation.
+
+Expects a predictions JSONL with instance_id and model_patch per line.
+Optionally delegates to the official SWE-PolyBench harness (run_evaluation.py)
+if --use-official and repo path are provided; otherwise computes pass rate
+from a results file or placeholder.
+
+Usage:
+  python evaluate.py --dataset-path data/polybench_500.jsonl --predictions-path predictions.jsonl --result-path ./eval_results
+  python evaluate.py --dataset-path data/polybench_500.jsonl --predictions-path predictions.jsonl --result-path ./eval_results --use-official --polybench-repo /path/to/SWE-PolyBench
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="SWE-PolyBench evaluation: accuracy/pass-rate")
+    parser.add_argument("--dataset-path", type=Path, required=True, help="Path to dataset JSONL (e.g. polybench_500.jsonl)")
+    parser.add_argument("--predictions-path", type=Path, required=True, help="Path to model predictions JSONL (instance_id, model_patch)")
+    parser.add_argument("--result-path", type=Path, required=True, help="Directory for instance-level results and summary")
+    parser.add_argument("--use-official", action="store_true", help="Run official SWE-PolyBench run_evaluation.py (requires --polybench-repo)")
+    parser.add_argument("--polybench-repo", type=Path, default=None, help="Path to cloned amazon-science/SWE-PolyBench repo for official eval")
+    parser.add_argument("--num-threads", type=int, default=1, help="Threads for official evaluator")
+    parser.add_argument("--repo-path", type=Path, default=None, help="Repository path passed to official evaluator (optional)")
+    args = parser.parse_args()
+
+    args.result_path.mkdir(parents=True, exist_ok=True)
+
+    if args.use_official and not args.polybench_repo:
+        print("--polybench-repo is required when --use-official is set.", file=sys.stderr)
+        return 1
+
+    if args.use_official and args.polybench_repo:
+        repo_dir = args.polybench_repo.resolve()
+        if not repo_dir.is_dir():
+            print(f"--polybench-repo is not an existing directory: {args.polybench_repo}", file=sys.stderr)
+            return 1
+        run_script = repo_dir / "src" / "poly_bench_evaluation" / "run_evaluation.py"
+        if not run_script.is_file():
+            print(f"Official evaluator not found: {run_script}", file=sys.stderr)
+            return 1
+        cmd = [
+            sys.executable,
+            str(run_script),
+            "--dataset-path", str(args.dataset_path.resolve() if args.dataset_path.is_file() else args.dataset_path),
+            "--predictions-path", str(args.predictions_path.resolve()),
+            "--result-path", str(args.result_path.resolve()),
+            "--num-threads", str(args.num_threads),
+            "--delete-image",
+        ]
+        if args.repo_path is not None:
+            cmd.extend(["--repo-path", str(args.repo_path.resolve())])
+        # subprocess.run uses shell=False; cwd and script path are operator-controlled.
+        try:
+            subprocess.run(cmd, cwd=str(repo_dir), check=True)
+        except subprocess.CalledProcessError as e:
+            return e.returncode
+        # Official script writes result.json and prints pass rate
+        result_file = repo_dir / "result.json"
+        summary = {}
+        if result_file.exists():
+            try:
+                with open(result_file, encoding="utf-8") as f:
+                    summary = json.load(f)
+            except (json.JSONDecodeError, OSError) as e:
+                print(f"Error reading {result_file!r}: {e}", file=sys.stderr)
+                summary = {"pass_rate": None}
+        print("Pass rate / resolved:", summary.get("pass_rate"), summary.get("resolved", ""))
+        return 0
+
+    # Lightweight path: validate dataset, then count predictions and optionally aggregate existing results
+    if not args.dataset_path.exists():
+        print(f"Dataset file not found: {args.dataset_path}", file=sys.stderr)
+        return 1
+    try:
+        with open(args.dataset_path, encoding="utf-8") as f:
+            _ = [json.loads(line) for line in f if line.strip()]
+    except OSError as e:
+        print(f"Cannot read dataset: {args.dataset_path}: {e}", file=sys.stderr)
+        return 1
+    except json.JSONDecodeError as e:
+        print(f"Invalid JSONL in dataset {args.dataset_path}: {e}", file=sys.stderr)
+        return 1
+
+    if not args.predictions_path.exists():
+        print(f"Predictions file not found: {args.predictions_path}", file=sys.stderr)
+        return 1
+    try:
+        with open(args.predictions_path, encoding="utf-8") as f:
+            preds = [json.loads(line) for line in f if line.strip()]
+        for p in preds:
+            if "model_patch" not in p and "patch" in p:
+                p["model_patch"] = p["patch"]
+    except OSError as e:
+        print(f"Error reading predictions file {args.predictions_path!r}: {e}", file=sys.stderr)
+        return 1
+    except json.JSONDecodeError as e:
+        print(f"Invalid JSON in predictions file {args.predictions_path!r}: {e}", file=sys.stderr)
+        return 1
+    if not all("instance_id" in p and "model_patch" in p for p in preds):
+        print("Predictions must have instance_id and model_patch (or patch) per line", file=sys.stderr)
+        return 1
+    summary = {
+        "num_predictions": len(preds),
+        "pass_rate": None,
+        "resolved": None,
+        "note": "Run with --use-official --polybench-repo /path/to/SWE-PolyBench for full pass-rate evaluation.",
+    }
+    out_summary = args.result_path / "evaluate_summary.json"
+    try:
+        with open(out_summary, "w", encoding="utf-8") as f:
+            json.dump(summary, f, indent=2)
+    except OSError as e:
+        print(f"Error writing {out_summary!r}: {e}", file=sys.stderr)
+        return 1
+    print(f"Wrote {out_summary}. {len(preds)} predictions. Use --use-official for pass-rate.", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/external/swe-polybench/evaluation/evaluate.py
+++ b/external/swe-polybench/evaluation/evaluate.py
@@ -24,6 +24,14 @@ import sys
 from pathlib import Path
 
 
+def positive_int(value: str) -> int:
+    """Argparse type: require a positive integer."""
+    n = int(value)
+    if n <= 0:
+        raise argparse.ArgumentTypeError(f"{value!r} is not a positive integer")
+    return n
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="SWE-PolyBench evaluation: accuracy/pass-rate")
     parser.add_argument("--dataset-path", type=Path, required=True, help="Path to dataset JSONL (e.g. polybench_500.jsonl)")
@@ -31,7 +39,7 @@ def main() -> int:
     parser.add_argument("--result-path", type=Path, required=True, help="Directory for instance-level results and summary")
     parser.add_argument("--use-official", action="store_true", help="Run official SWE-PolyBench run_evaluation.py (requires --polybench-repo)")
     parser.add_argument("--polybench-repo", type=Path, default=None, help="Path to cloned amazon-science/SWE-PolyBench repo for official eval")
-    parser.add_argument("--num-threads", type=int, default=1, help="Threads for official evaluator")
+    parser.add_argument("--num-threads", type=positive_int, default=1, help="Threads for official evaluator (must be >= 1)")
     parser.add_argument("--repo-path", type=Path, default=None, help="Repository path passed to official evaluator (optional)")
     args = parser.parse_args()
 

--- a/external/swe-polybench/evaluation/evaluate.py
+++ b/external/swe-polybench/evaluation/evaluate.py
@@ -76,14 +76,15 @@ def main() -> int:
             return e.returncode
         # Official script writes result.json under args.result_path
         result_file = args.result_path / "result.json"
-        summary = {}
-        if result_file.exists():
-            try:
-                with open(result_file, encoding="utf-8") as f:
-                    summary = json.load(f)
-            except (json.JSONDecodeError, OSError) as e:
-                print(f"Error reading {result_file!r}: {e}", file=sys.stderr)
-                summary = {"pass_rate": None}
+        if not result_file.exists():
+            print(f"Result file not found: {result_file!r}", file=sys.stderr)
+            return 1
+        try:
+            with open(result_file, encoding="utf-8") as f:
+                summary = json.load(f)
+        except (json.JSONDecodeError, OSError) as e:
+            print(f"Error reading {result_file!r}: {e}", file=sys.stderr)
+            return 1
         print("Pass rate / resolved:", summary.get("pass_rate"), summary.get("resolved", ""))
         return 0
 
@@ -108,6 +109,8 @@ def main() -> int:
         with open(args.predictions_path, encoding="utf-8") as f:
             preds = [json.loads(line) for line in f if line.strip()]
         for p in preds:
+            if not isinstance(p, dict):
+                continue
             if "model_patch" not in p and "patch" in p:
                 p["model_patch"] = p["patch"]
     except OSError as e:

--- a/external/swe-polybench/evaluation/evaluate.py
+++ b/external/swe-polybench/evaluation/evaluate.py
@@ -116,8 +116,18 @@ def main() -> int:
     except json.JSONDecodeError as e:
         print(f"Invalid JSON in predictions file {args.predictions_path!r}: {e}", file=sys.stderr)
         return 1
-    if not all("instance_id" in p and "model_patch" in p for p in preds):
-        print("Predictions must have instance_id and model_patch (or patch) per line", file=sys.stderr)
+    def _valid_pred(p):
+        return (
+            isinstance(p, dict)
+            and p.get("instance_id")
+            and (p.get("model_patch") or p.get("patch"))
+        )
+
+    if not all(_valid_pred(p) for p in preds):
+        print(
+            "Predictions must have non-empty instance_id and non-empty model_patch (or patch) per line",
+            file=sys.stderr,
+        )
         return 1
     summary = {
         "num_predictions": len(preds),

--- a/external/swe-polybench/evaluation/evaluate.py
+++ b/external/swe-polybench/evaluation/evaluate.py
@@ -74,6 +74,9 @@ def main() -> int:
             subprocess.run(cmd, cwd=str(repo_dir), check=True)
         except subprocess.CalledProcessError as e:
             return e.returncode
+        except OSError as e:
+            print(f"Failed to start official evaluator: {e}", file=sys.stderr)
+            return 1
         # Official script writes result.json under args.result_path
         result_file = args.result_path / "result.json"
         if not result_file.exists():

--- a/external/swe-polybench/evaluation/evaluate.py
+++ b/external/swe-polybench/evaluation/evaluate.py
@@ -74,8 +74,8 @@ def main() -> int:
             subprocess.run(cmd, cwd=str(repo_dir), check=True)
         except subprocess.CalledProcessError as e:
             return e.returncode
-        # Official script writes result.json and prints pass rate
-        result_file = repo_dir / "result.json"
+        # Official script writes result.json under args.result_path
+        result_file = args.result_path / "result.json"
         summary = {}
         if result_file.exists():
             try:

--- a/external/swe-polybench/scripts/download.py
+++ b/external/swe-polybench/scripts/download.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""
+Download SWE-PolyBench 500 subset from Hugging Face and write JSONL.
+
+The official SWE-PolyBench_500 dataset contains only Java, JavaScript,
+TypeScript, and Python (125 per language). There are no C/C++ issues.
+No C/C++ subset is produced; use other benchmarks in this repo for C/C++.
+
+1. Load AmazonScience/SWE-PolyBench_500 (500 instances).
+2. Write full 500 to data/polybench_500.jsonl (one JSON object per line).
+
+Required: pip install datasets
+
+Usage:
+  python download.py [--output-dir PATH]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def row_to_record(row, columns: list) -> dict:
+    """Convert a dataset row to our JSONL record with required fields."""
+    d = {}
+    for col in columns:
+        if col not in row:
+            continue
+        v = row[col]
+        if hasattr(v, "tolist"):  # numpy etc.
+            v = v.tolist()
+        d[col] = v
+    # Ensure required fields for acceptance criteria
+    out = {
+        "language": d.get("language", ""),
+        "repo": d.get("repo", ""),
+        "issue_text": d.get("problem_statement", ""),
+        "test_cmd": d.get("test_command", ""),
+        "expected_patch": d.get("patch", ""),
+    }
+    out["instance_id"] = d.get("instance_id", "")
+    out["base_commit"] = d.get("base_commit", "")
+    out["F2P"] = d.get("F2P", "")
+    out["P2P"] = d.get("P2P", "")
+    out["task_category"] = d.get("task_category", "")
+    out["patch"] = d.get("patch", "")
+    out["problem_statement"] = d.get("problem_statement", "")
+    out["test_command"] = d.get("test_command", "")
+    if "Dockerfile" in d:
+        out["Dockerfile"] = d["Dockerfile"]
+    return out
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Download SWE-PolyBench 500 and write JSONL")
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Output directory (default: data/ under repo root)",
+    )
+    parser.add_argument(
+        "--dataset-name",
+        type=str,
+        default="AmazonScience/SWE-PolyBench_500",
+        help="Hugging Face dataset name",
+    )
+    args = parser.parse_args()
+
+    script_dir = Path(__file__).resolve().parent
+    root = script_dir.parent
+    out_dir = args.output_dir or (root / "data")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    path_500 = out_dir / "polybench_500.jsonl"
+
+    try:
+        from datasets import load_dataset
+        from datasets.exceptions import DatasetNotFoundError
+    except ImportError:
+        print("Install datasets: pip install datasets", file=sys.stderr)
+        return 1
+
+    print(f"Loading {args.dataset_name} from Hugging Face...", file=sys.stderr)
+    try:
+        ds = load_dataset(args.dataset_name, split="test")
+    except (OSError, ValueError, DatasetNotFoundError) as e:
+        print(f"Failed to load dataset: {e}", file=sys.stderr)
+        return 1
+
+    columns = list(ds.column_names)
+    records = [row_to_record(ds[i], columns) for i in range(len(ds))]
+    print(f"Loaded {len(records)} instances.", file=sys.stderr)
+
+    with open(path_500, "w", encoding="utf-8") as f:
+        for r in records:
+            f.write(json.dumps(r, ensure_ascii=False) + "\n")
+    print(f"Wrote {path_500} ({len(records)} instances).", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/external/swe-polybench/scripts/download.py
+++ b/external/swe-polybench/scripts/download.py
@@ -22,6 +22,24 @@ import sys
 from pathlib import Path
 
 
+REQUIRED_ROW_KEYS = (
+    "language",
+    "repo",
+    "problem_statement",
+    "test_command",
+    "patch",
+    "instance_id",
+    "base_commit",
+)
+
+
+def _empty(val) -> bool:
+    """True if value is missing or empty (None, empty string, or whitespace-only)."""
+    if val is None:
+        return True
+    return str(val).strip() == ""
+
+
 def row_to_record(row, columns: list) -> dict:
     """Convert a dataset row to our JSONL record with required fields."""
     d = {}
@@ -32,22 +50,24 @@ def row_to_record(row, columns: list) -> dict:
         if hasattr(v, "tolist"):  # numpy etc.
             v = v.tolist()
         d[col] = v
-    # Ensure required fields for acceptance criteria
+    missing = [k for k in REQUIRED_ROW_KEYS if k not in d or _empty(d[k])]
+    if missing:
+        raise ValueError(f"Row missing or empty required keys: {missing}")
     out = {
-        "language": d.get("language", ""),
-        "repo": d.get("repo", ""),
-        "issue_text": d.get("problem_statement", ""),
-        "test_cmd": d.get("test_command", ""),
-        "expected_patch": d.get("patch", ""),
+        "language": d["language"],
+        "repo": d["repo"],
+        "issue_text": d["problem_statement"],
+        "test_cmd": d["test_command"],
+        "expected_patch": d["patch"],
     }
-    out["instance_id"] = d.get("instance_id", "")
-    out["base_commit"] = d.get("base_commit", "")
+    out["instance_id"] = d["instance_id"]
+    out["base_commit"] = d["base_commit"]
     out["F2P"] = d.get("F2P", "")
     out["P2P"] = d.get("P2P", "")
     out["task_category"] = d.get("task_category", "")
-    out["patch"] = d.get("patch", "")
-    out["problem_statement"] = d.get("problem_statement", "")
-    out["test_command"] = d.get("test_command", "")
+    out["patch"] = d["patch"]
+    out["problem_statement"] = d["problem_statement"]
+    out["test_command"] = d["test_command"]
     if "Dockerfile" in d:
         out["Dockerfile"] = d["Dockerfile"]
     return out
@@ -93,9 +113,16 @@ def main() -> int:
     records = [row_to_record(ds[i], columns) for i in range(len(ds))]
     print(f"Loaded {len(records)} instances.", file=sys.stderr)
 
-    with open(path_500, "w", encoding="utf-8") as f:
-        for r in records:
-            f.write(json.dumps(r, ensure_ascii=False) + "\n")
+    try:
+        with open(path_500, "w", encoding="utf-8") as f:
+            for r in records:
+                f.write(json.dumps(r, ensure_ascii=False) + "\n")
+    except Exception as e:
+        print(
+            f"Failed to write {path_500} ({len(records)} records): {e}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
     print(f"Wrote {path_500} ({len(records)} instances).", file=sys.stderr)
     return 0
 

--- a/external/swe-polybench/scripts/download.py
+++ b/external/swe-polybench/scripts/download.py
@@ -117,12 +117,12 @@ def main() -> int:
         with open(path_500, "w", encoding="utf-8") as f:
             for r in records:
                 f.write(json.dumps(r, ensure_ascii=False) + "\n")
-    except Exception as e:
+    except OSError as e:
         print(
             f"Failed to write {path_500} ({len(records)} records): {e}",
             file=sys.stderr,
         )
-        sys.exit(1)
+        return 1
     print(f"Wrote {path_500} ({len(records)} instances).", file=sys.stderr)
     return 0
 

--- a/external/swe-polybench/scripts/requirements.txt
+++ b/external/swe-polybench/scripts/requirements.txt
@@ -1,0 +1,2 @@
+# SWE-PolyBench download (external/swe-polybench)
+datasets>=2.14.0


### PR DESCRIPTION
Closes #9 

* **New Features**
  * Added a SWE-PolyBench 500 download tool and an evaluation runner supporting lightweight and optional official evaluation modes.

* **Documentation**
  * Added README and methodology docs with quick-start commands, dataset scope, evaluation guidance, replication plans, and acceptance criteria.

* **Chores**
  * Added a JSON evaluation summary artifact and a small requirements file for dataset downloading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dataset download utility for the SWE-PolyBench 500 subset and an evaluation runner with optional official-harness integration
  * Added a static evaluation summary output file

* **Documentation**
  * Added README with quick start, dataset layout, and acceptance criteria
  * Added methodology doc describing dataset composition, language breakdown, task formats, evaluation workflow, and selection methodology

* **Chores**
  * Added dependency spec for the dataset download utility
<!-- end of auto-generated comment: release notes by coderabbit.ai -->